### PR TITLE
fix early return

### DIFF
--- a/freezer_source.go
+++ b/freezer_source.go
@@ -77,7 +77,7 @@ func (mq *messageSource) ConsumeMessages(ctx context.Context, handler ConsumerMe
 		for {
 			lenBytes := []byte{0, 0, 0, 0}
 			_, err := rc.Read(lenBytes[:])
-			if err != io.EOF && err != nil {
+			if err != nil && err != io.EOF {
 				return err
 			}
 


### PR DESCRIPTION
A reader can return EOF even if the bytes are read

https://golang.org/pkg/io/#Reader