### PR TITLE
Added compression option

### DIFF
--- a/compression.go
+++ b/compression.go
@@ -1,0 +1,132 @@
+package freezer
+
+import (
+	"io"
+	"os"
+	"time"
+
+	"github.com/golang/snappy"
+	"github.com/uw-labs/straw"
+)
+
+type CompressionType int
+
+const (
+	CompressionTypeNone   CompressionType = 0
+	CompressionTypeSnappy CompressionType = 1
+)
+
+var _ straw.StreamStore = &snappyStreamStore{}
+
+func newSnappyStreamStore(store straw.StreamStore) *snappyStreamStore {
+	return &snappyStreamStore{store}
+}
+
+// snappyStreamStore is a straw.StreamStore wrapper that implements transparent snappy compression. Everything is supported, except for calling Size() on the os.FileInfo returned from Stat or Lstat.  Calling Size() like this will panic, but freezer does not need that functionality anyway.
+type snappyStreamStore struct {
+	store straw.StreamStore
+}
+
+func (fs *snappyStreamStore) Lstat(name string) (os.FileInfo, error) {
+	fi, err := fs.store.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	return &noSizeFileInfo{fi}, nil
+}
+
+func (fs *snappyStreamStore) Stat(name string) (os.FileInfo, error) {
+	fi, err := fs.store.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+	return &noSizeFileInfo{fi}, nil
+}
+
+func (fs *snappyStreamStore) OpenReadCloser(name string) (straw.StrawReader, error) {
+	rc, err := fs.store.OpenReadCloser(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &snappyReadCloser{snappy.NewReader(rc), rc}, nil
+}
+
+func (fs *snappyStreamStore) Mkdir(name string, mode os.FileMode) error {
+	return fs.store.Mkdir(name, mode)
+}
+
+func (fs *snappyStreamStore) Remove(name string) error {
+	return fs.store.Remove(name)
+}
+
+func (fs *snappyStreamStore) CreateWriteCloser(name string) (straw.StrawWriter, error) {
+	wc, err := fs.store.CreateWriteCloser(name)
+	if err != nil {
+		return nil, err
+	}
+	return &snappyWriteCloser{snappy.NewBufferedWriter(wc), wc}, nil
+}
+
+func (fs *snappyStreamStore) Readdir(name string) ([]os.FileInfo, error) {
+	return fs.store.Readdir(name)
+}
+
+type snappyReadCloser struct {
+	sr    io.Reader
+	inner io.Closer
+}
+
+func (src *snappyReadCloser) Read(buf []byte) (int, error) {
+	return src.sr.Read(buf)
+}
+
+func (src *snappyReadCloser) Close() error {
+	return src.inner.Close()
+}
+
+type snappyWriteCloser struct {
+	swc   io.WriteCloser
+	inner io.Closer
+}
+
+func (src *snappyWriteCloser) Write(buf []byte) (int, error) {
+	return src.swc.Write(buf)
+}
+
+func (src *snappyWriteCloser) Close() error {
+	if err := src.swc.Close(); err != nil {
+		_ = src.inner.Close()
+		return err
+	}
+	return src.inner.Close()
+}
+
+// noSizeFileInfo wraps another os.FileInfo but will panic if Size() is called.
+type noSizeFileInfo struct {
+	fi os.FileInfo
+}
+
+func (n *noSizeFileInfo) Name() string {
+	return n.fi.Name()
+}
+
+func (n *noSizeFileInfo) Size() int64 {
+	panic("Size() is not implemented here")
+}
+
+func (n *noSizeFileInfo) Mode() os.FileMode {
+	return n.fi.Mode()
+}
+
+func (n *noSizeFileInfo) ModTime() time.Time {
+	return n.fi.ModTime()
+}
+
+func (n *noSizeFileInfo) IsDir() bool {
+	return n.fi.IsDir()
+}
+
+func (n *noSizeFileInfo) Sys() interface{} {
+	return nil
+}

--- a/freezer_sink.go
+++ b/freezer_sink.go
@@ -29,6 +29,7 @@ type MessageSinkConfig struct {
 	Path                 string
 	MaxUnflushedTime     time.Duration
 	MaxUnflushedMessages int
+	CompressionType      CompressionType
 }
 
 const (
@@ -50,6 +51,12 @@ func NewMessageSink(streamstore straw.StreamStore, config MessageSinkConfig) (*m
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	switch config.CompressionType {
+	case CompressionTypeNone:
+	case CompressionTypeSnappy:
+		streamstore = newSnappyStreamStore(streamstore)
 	}
 
 	ms := &messageSink{

--- a/freezer_source.go
+++ b/freezer_source.go
@@ -20,11 +20,19 @@ type messageSource struct {
 }
 
 type MessageSourceConfig struct {
-	Path       string
-	PollPeriod time.Duration
+	Path            string
+	PollPeriod      time.Duration
+	CompressionType CompressionType
 }
 
 func NewMessageSource(streamstore straw.StreamStore, config MessageSourceConfig) *messageSource {
+
+	switch config.CompressionType {
+	case CompressionTypeNone:
+	case CompressionTypeSnappy:
+		streamstore = newSnappyStreamStore(streamstore)
+	}
+
 	ms := &messageSource{
 		streamstore: streamstore,
 		path:        config.Path,


### PR DESCRIPTION
This introduces optional snappy compression to the configuration.

Why snappy?

Typically, snappy represents extremely low CPU overhead but still gives
worthwhile compression (~50% in my unscientific testing with some real
life protocol buffers messages)

Alternatives to snappy include lz4, but the advantage of snappy,
especially in Go is the existence of optimised asm code, making it ~10x
faster than lz4.

Why configuration?

Given it's characteristics, there is an argument to just always use
snappy compression and not add the complexity of another config option,
but there are two arguments against this:

1) The uncompressed version is already being used and this would break
compatability
2) It's possibly to imagine cases in future of large, low throughput
messages where other, slower and better compressing algorithms might be
wanted.

The default compression is None (for compatability), and for the moment
CompressionTypeSnappy is the only supported one.

This could be implemented instead as a decorator StreamStore in straw if
we can find a reasonable way to implement Stat().Size() correctly.

Question : Should we support something like CompressionTypeAutoDetect on
the consume side and haave it work on a per-file basis?  That would allow
flexibility of switching on compression for future files without a
migration effort.   If we want this, we might want to do it before
merging this.