### PR TITLE
Export types

### DIFF
--- a/freezer_sink.go
+++ b/freezer_sink.go
@@ -11,7 +11,7 @@ import (
 	"github.com/uw-labs/straw"
 )
 
-type messageSink struct {
+type MessageSink struct {
 	streamstore straw.StreamStore
 	path        string
 
@@ -36,7 +36,7 @@ const (
 	DefaultMaxUnflushedTime = time.Second * 10
 )
 
-func NewMessageSink(streamstore straw.StreamStore, config MessageSinkConfig) (*messageSink, error) {
+func NewMessageSink(streamstore straw.StreamStore, config MessageSinkConfig) (*MessageSink, error) {
 
 	if config.MaxUnflushedTime == 0 {
 		config.MaxUnflushedTime = DefaultMaxUnflushedTime
@@ -59,7 +59,7 @@ func NewMessageSink(streamstore straw.StreamStore, config MessageSinkConfig) (*m
 		streamstore = newSnappyStreamStore(streamstore)
 	}
 
-	ms := &messageSink{
+	ms := &MessageSink{
 		streamstore: streamstore,
 		path:        config.Path,
 		reqs:        make(chan *messageReq),
@@ -85,12 +85,12 @@ func NewMessageSink(streamstore straw.StreamStore, config MessageSinkConfig) (*m
 	return ms, nil
 }
 
-func (mq *messageSink) run(nextSeq int) {
+func (mq *MessageSink) run(nextSeq int) {
 	mq.exitErr = mq.loop(nextSeq)
 	close(mq.closed)
 }
 
-func (mq *messageSink) loop(nextSeq int) error {
+func (mq *MessageSink) loop(nextSeq int) error {
 	writtenCount := 0
 	var t *time.Timer
 	var timerC <-chan time.Time
@@ -165,7 +165,7 @@ type messageReq struct {
 	writtenOk chan struct{}
 }
 
-func (mq *messageSink) PutMessage(m []byte) error {
+func (mq *MessageSink) PutMessage(m []byte) error {
 	req := &messageReq{m, make(chan struct{})}
 	select {
 	case mq.reqs <- req:
@@ -180,7 +180,7 @@ func (mq *messageSink) PutMessage(m []byte) error {
 	}
 }
 
-func (mq *messageSink) Close() error {
+func (mq *MessageSink) Close() error {
 	select {
 	case mq.closeReq <- struct{}{}:
 		<-mq.closed

--- a/freezer_source.go
+++ b/freezer_source.go
@@ -13,7 +13,7 @@ import (
 
 type ConsumerMessageHandler func([]byte) error
 
-type messageSource struct {
+type MessageSource struct {
 	streamstore straw.StreamStore
 	path        string
 	pollPeriod  time.Duration
@@ -25,7 +25,7 @@ type MessageSourceConfig struct {
 	CompressionType CompressionType
 }
 
-func NewMessageSource(streamstore straw.StreamStore, config MessageSourceConfig) *messageSource {
+func NewMessageSource(streamstore straw.StreamStore, config MessageSourceConfig) *MessageSource {
 
 	switch config.CompressionType {
 	case CompressionTypeNone:
@@ -33,7 +33,7 @@ func NewMessageSource(streamstore straw.StreamStore, config MessageSourceConfig)
 		streamstore = newSnappyStreamStore(streamstore)
 	}
 
-	ms := &messageSource{
+	ms := &MessageSource{
 		streamstore: streamstore,
 		path:        config.Path,
 		pollPeriod:  config.PollPeriod,
@@ -44,7 +44,7 @@ func NewMessageSource(streamstore straw.StreamStore, config MessageSourceConfig)
 	return ms
 }
 
-func (mq *messageSource) ConsumeMessages(ctx context.Context, handler ConsumerMessageHandler) error {
+func (mq *MessageSource) ConsumeMessages(ctx context.Context, handler ConsumerMessageHandler) error {
 	for seq := 0; ; seq++ {
 		fullname := seqToPath(mq.path, seq)
 


### PR DESCRIPTION
This exports MessageSource and MessageSink.  It's bad practice to return
unexported types from exported functions, and it means the caller can't
invoke methods on the returned objects without defining their own
interface.  These types are the main types of this package and simply
should be exported.