### PR TITLE
Fix memory leak

### DIFF
--- a/freezer_source.go
+++ b/freezer_source.go
@@ -45,17 +45,18 @@ func NewMessageSource(streamstore straw.StreamStore, config MessageSourceConfig)
 }
 
 func (mq *MessageSource) ConsumeMessages(ctx context.Context, handler ConsumerMessageHandler) error {
+
+	var err error
+	var rc io.ReadCloser
+
+	defer func() {
+		if rc != nil {
+			rc.Close()
+		}
+	}()
+
 	for seq := 0; ; seq++ {
 		fullname := seqToPath(mq.path, seq)
-
-		var rc io.ReadCloser
-		var err error
-
-		defer func() {
-			if rc != nil {
-				rc.Close()
-			}
-		}()
 
 	waitLoop:
 		for {


### PR DESCRIPTION
This moves the defer, that is intended to ensure the last input is closed
regardless of how we exit, to outside the main loop.  Being inside was
not only wrong (we should only check the last one, not every one) but it
caused a lingering reference to every stream opened, causing excessive
memory usage.