### PR TITLE
Prevent zero length messages

### DIFF
--- a/freezer_sink_manual.go
+++ b/freezer_sink_manual.go
@@ -134,7 +134,12 @@ type messageReq struct {
 	writtenOk chan struct{}
 }
 
+var errZeroLengthMessage = errors.New("freezer does not support messages of 0 length")
+
 func (mq *MessageSink) PutMessage(m []byte) error {
+	if len(m) == 0 {
+		return errZeroLengthMessage
+	}
 	req := &messageReq{m, make(chan struct{})}
 	select {
 	case mq.reqs <- req:


### PR DESCRIPTION
Due to the design of the on-disk format of freezer, it does not support
zero length messages.  If we allow a zero length message to be written
by the sink, it is indistinguishable om disk from the internally used
end marker, and when being read as a source, is detected as a corrupt
stream.

Avoid this problem by explicitly dis-allowing empty messages and
returning an error if the caller attempts to write one.